### PR TITLE
Fix lap count

### DIFF
--- a/PlayerState/AR_Data.as
+++ b/PlayerState/AR_Data.as
@@ -248,10 +248,8 @@ namespace PlayerState
 				PlayerState = EPlayerState::EPlayerState_EndRace; // Manually adjust to end race to get the event later in this function
 			}
 
-			int LapCPs = dMLData.NumCPs - dPlayerInfo.CurrentLapNumber * dMapInfo.NumberOfCheckpoints;
-
 			// Finish also counts as NumCPs but have been excluded from NumberOfCheckpoints
-			if(LapCPs  > dMapInfo.NumberOfCheckpoints && previous.PlayerState != EPlayerState::EPlayerState_Finished && !IsSpectator && PlayerState == EPlayerState_Driving)
+			if(dPlayerInfo.NumberOfCheckpointsPassed  > dMapInfo.NumberOfCheckpoints && previous.PlayerState != EPlayerState::EPlayerState_Finished && !IsSpectator && PlayerState == EPlayerState_Driving)
 			{
 				if(dMapInfo.IsFinish(dPlayerInfo.LatestCheckpointLandmarkIndex))
 				{


### PR DESCRIPTION
Fixes issue where lap count is incremented multiple times per lap after some number of laps.

Most noticeably the issue causes "Checkpoint Counter by Phlarx" to underflow the current CP number and show the wrong lap number.

I used "99 laps of high octane gaming by SqueakyTomato" for reproducing the issue and verifying the fix.